### PR TITLE
Test fails when not in EST

### DIFF
--- a/strftime_test.go
+++ b/strftime_test.go
@@ -2,13 +2,14 @@ package strftime
 
 import (
 	"time"
-	"testing"
+	"fmt"
 )
 
-func TestFormat(t *testing.T) {
-	tt := time.Unix(1340244776, 0)
-	f := Format("%Y-%m-%d %H:%M:%S", tt)
-	if f != "2012-06-20 22:12:56" {
-		t.Errorf("got %s", f)
-	}
+func ExampleFormat() {
+	t := time.Unix(1340244776, 0)
+	utc, _ := time.LoadLocation("UTC")
+	t = t.In(utc)
+	fmt.Println(Format("%Y-%m-%d %H:%M:%S", t))
+	// Output:
+	// 2012-06-21 02:12:56
 }


### PR DESCRIPTION
I got "2012-06-20 19:12:56", which is 3 hours before the desired "2012-06-20 22:12:56".  Looks like this is because I'm in Pacific time, not Eastern.
