### PR TITLE
add support for the Ruby strftime %L formatter (millisecond precision)

### DIFF
--- a/strftime.go
+++ b/strftime.go
@@ -7,8 +7,8 @@ import (
 )
 
 // taken from time/format.go
-var conversion = map[rune]string {
-	/*stdLongMonth      */ 'B':"January",
+var conversion = map[rune]string{
+	/*stdLongMonth      */ 'B': "January",
 	/*stdMonth          */ 'b': "Jan",
 	// stdNumMonth       */ 'm': "1",
 	/*stdZeroMonth      */ 'm': "01",
@@ -31,12 +31,13 @@ var conversion = map[rune]string {
 	/*stdTZ             */ 'Z': "MST",
 	// stdISO8601TZ      */ 'z': "Z0700",  // prints Z for UTC
 	// stdISO8601ColonTZ */ 'z': "Z07:00", // prints Z for UTC
-	/*stdNumTZ          */ 'z': "-0700",  // always numeric
+	/*stdNumTZ          */ 'z': "-0700", // always numeric
 	// stdNumShortTZ     */ 'b': "-07",    // always numeric
 	// stdNumColonTZ     */ 'b': "-07:00", // always numeric
+	/* nonStdMilli		 */ 'L': ".000",
 }
 
-// This is an alternative to time.Format because no one knows 
+// This is an alternative to time.Format because no one knows
 // what date 040305 is supposed to create when used as a 'layout' string
 // this takes standard strftime format options. For a complete list
 // of format options see http://strftime.org/
@@ -50,8 +51,8 @@ func Format(format string, t time.Time) string {
 			ni += i
 		}
 		retval = append(retval, []byte(format[i:ni])...)
-		if ni + 1 < len(format) {
-			c := format[ni + 1]
+		if ni+1 < len(format) {
+			c := format[ni+1]
 			if c == '%' {
 				retval = append(retval, '%')
 			} else {

--- a/strftime_test.go
+++ b/strftime_test.go
@@ -1,9 +1,9 @@
 package strftime
 
 import (
-	"time"
 	"fmt"
 	"testing"
+	"time"
 )
 
 func ExampleFormat() {
@@ -26,7 +26,6 @@ func TestNoLeadingPercentSign(t *testing.T) {
 	}
 }
 
-
 func TestUnsupported(t *testing.T) {
 	tm := time.Unix(1340244776, 0)
 	utc, _ := time.LoadLocation("UTC")
@@ -38,3 +37,13 @@ func TestUnsupported(t *testing.T) {
 	}
 }
 
+func TestRubyStftime(t *testing.T) {
+	tm := time.Unix(1340244776, 0)
+	utc, _ := time.LoadLocation("UTC")
+	tm = tm.In(utc)
+	result := Format("%H:%M:%S%L", tm)
+	if result != "02:12:56.000" {
+		t.Logf("%s != %s", result, "02:12:56.000")
+		t.Fail()
+	}
+}


### PR DESCRIPTION
This adds support for the extension of the `strftime` as added within Ruby. This adds the `%L` conversion string which will give millisecond precision with a `.` character in the front. So `%H:%M:%S%L` would become `02:12:56.000`.

In addition, `go fmt`/`goimports` made some adjustments to the alignment of the code in certain places.