### PR TITLE
fix typo in Ruby strftime test function name

### DIFF
--- a/strftime_test.go
+++ b/strftime_test.go
@@ -37,7 +37,7 @@ func TestUnsupported(t *testing.T) {
 	}
 }
 
-func TestRubyStftime(t *testing.T) {
+func TestRubyStrftime(t *testing.T) {
 	tm := time.Unix(1340244776, 0)
 	utc, _ := time.LoadLocation("UTC")
 	tm = tm.In(utc)


### PR DESCRIPTION
In PR #4, a test function was added to test the Ruby strftime formatter for millisecond precision. Unfortunately, I just noticed there is a typo in the name of the function (`Stftime` instead of `Strftime`).

This change addresses the issue caused by my fat fingers.